### PR TITLE
PostCreatePage 렌더링 비용 절감을 위한 리펙토링

### DIFF
--- a/src/hooks/useForm.js
+++ b/src/hooks/useForm.js
@@ -1,19 +1,19 @@
-import { useState } from 'react';
+import { useState, useCallback } from 'react';
 
 const useForm = ({ initialValues, onSubmit, validate, handleNavigate, handleErrors }) => {
   const [values, setValues] = useState(initialValues);
   const [errors, setErrors] = useState({});
   const [isLoading, setIsLoading] = useState(false);
 
-  const handleFillIn = (param) => {
+  const handleFillIn = useCallback((param) => {
     setValues((values) => ({ ...values, ...param }));
-  };
+  }, []);
 
-  const handleLeaveBlank = (param, blankValue) => {
+  const handleLeaveBlank = useCallback((param, blankValue) => {
     setValues((values) => ({ ...values, [param]: blankValue || null }));
-  };
+  }, []);
 
-  const handleSubmit = async (e) => {
+  const handleSubmit = useCallback(async (e) => {
     setIsLoading(true);
     e.preventDefault();
     const newErrors = (validate && validate(values)) || {};
@@ -27,7 +27,7 @@ const useForm = ({ initialValues, onSubmit, validate, handleNavigate, handleErro
     handleErrors && Object.keys(newErrors).length !== 0 && handleErrors();
     setIsLoading(false);
     onSubmitResult && handleNavigate(onSubmitResult);
-  };
+  }, []);
 
   return {
     values,

--- a/src/views/Post/PostCreatePage/Category/ChipInformation/ChipInformation.jsx
+++ b/src/views/Post/PostCreatePage/Category/ChipInformation/ChipInformation.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { memo } from 'react';
 import PropTypes from 'prop-types';
 import styled from '@emotion/styled';
 import { Label } from '@/components/Label';
@@ -35,6 +35,6 @@ ChipInformation.propTypes = {
   onLeaveBlank: PropTypes.func
 };
 
-export default ChipInformation;
+export default memo(ChipInformation);
 
 const isInputEmpty = (e) => e.target.value.length === 0;

--- a/src/views/Post/PostCreatePage/Category/Contact/Contact.jsx
+++ b/src/views/Post/PostCreatePage/Category/Contact/Contact.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { memo } from 'react';
 import PropTypes from 'prop-types';
 import styled from '@emotion/styled';
 import { Label } from '@/components/Label';
@@ -36,6 +36,6 @@ Contact.propTypes = {
   onLeaveBlank: PropTypes.func
 };
 
-export default Contact;
+export default memo(Contact);
 
 const isInputEmpty = (e) => e.target.value.length === 0;

--- a/src/views/Post/PostCreatePage/Category/Content/Content.jsx
+++ b/src/views/Post/PostCreatePage/Category/Content/Content.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { memo } from 'react';
 import PropTypes from 'prop-types';
 import styled from '@emotion/styled';
 import { Label } from '@/components/Label';
@@ -66,7 +66,7 @@ Content.propTypes = {
   onLeaveBlank: PropTypes.func
 };
 
-export default Content;
+export default memo(Content);
 
 const isInputEmpty = (string) => string.length === 0;
 const isPureTextLengthMoreThan255 = (e) => e.target.textContent.length >= 255;

--- a/src/views/Post/PostCreatePage/Category/Date/Date.jsx
+++ b/src/views/Post/PostCreatePage/Category/Date/Date.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, memo } from 'react';
 import PropTypes from 'prop-types';
 import styled from '@emotion/styled';
 import LineBreakWrapper from '../Common/LineBreakWrapper';
@@ -89,7 +89,7 @@ Date.propTypes = {
   margin: PropTypes.string
 };
 
-export default Date;
+export default memo(Date);
 
 const getRangeOfYear = () => {
   const thisYear = new window.Date().getFullYear();

--- a/src/views/Post/PostCreatePage/Category/HashTag/HashTag.jsx
+++ b/src/views/Post/PostCreatePage/Category/HashTag/HashTag.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, memo } from 'react';
 import PropTypes from 'prop-types';
 import styled from '@emotion/styled';
 import { Label } from '@/components/Label';
@@ -130,7 +130,7 @@ HashTag.propTypes = {
   onLeaveBlank: PropTypes.func
 };
 
-export default HashTag;
+export default memo(HashTag);
 
 const isTagsEmpty = (array) => array.length === 0;
 const isEnterEntered = (e) => e.key === 'Enter';

--- a/src/views/Post/PostCreatePage/Category/PetInformation/PetInformation.jsx
+++ b/src/views/Post/PostCreatePage/Category/PetInformation/PetInformation.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useRef, useMemo } from 'react';
+import React, { useState, useEffect, useRef, useMemo, memo } from 'react';
 import PropTypes from 'prop-types';
 import styled from '@emotion/styled';
 import LineBreakWrapper from '../Common/LineBreakWrapper';
@@ -175,7 +175,7 @@ PetInformation.propTypes = {
   margin: PropTypes.string
 };
 
-export default PetInformation;
+export default memo(PetInformation);
 
 const isSelectChange = (e) => e.target.tagName === 'SELECT';
 const isInputChange = (e) => e.target.tagName === 'INPUT';

--- a/src/views/Post/PostCreatePage/Category/PetPhoto/PetPhoto.jsx
+++ b/src/views/Post/PostCreatePage/Category/PetPhoto/PetPhoto.jsx
@@ -1,4 +1,4 @@
-import React, { useRef, useState } from 'react';
+import React, { useRef, useState, memo } from 'react';
 import styled from '@emotion/styled';
 import PropTypes from 'prop-types';
 import { Slider } from '@/components/Slider';
@@ -64,7 +64,7 @@ PetPhoto.propTypes = {
   margin: PropTypes.string
 };
 
-export default PetPhoto;
+export default memo(PetPhoto);
 
 const areFileSizesUnder5MB = (e) => {
   const { files } = e.target;

--- a/src/views/Post/PostCreatePage/Category/Place/Place.jsx
+++ b/src/views/Post/PostCreatePage/Category/Place/Place.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useRef, useMemo } from 'react';
+import React, { useState, useRef, useMemo, memo } from 'react';
 import PropTypes from 'prop-types';
 import styled from '@emotion/styled';
 import LineBreakWrapper from '../Common/LineBreakWrapper';
@@ -88,7 +88,7 @@ Place.propTypes = {
   margin: PropTypes.string
 };
 
-export default Place;
+export default memo(Place);
 
 const isDetailAddressEntered = (e) => e.target.tagName === 'INPUT';
 const isDefaultOptionSelected = (e) => e.target[0].textContent === e.target.value;

--- a/src/views/Post/PostCreatePage/Category/Status/Status.jsx
+++ b/src/views/Post/PostCreatePage/Category/Status/Status.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { memo } from 'react';
 import PropTypes from 'prop-types';
 import styled from '@emotion/styled';
 import LineBreakWrapper from '../Common/LineBreakWrapper';
@@ -44,5 +44,5 @@ Status.propTypes = {
   onLeaveBlank: PropTypes.func
 };
 
-export default Status;
+export default memo(Status);
 const isDefalutOptionSelected = (e) => e.target[0].textContent === e.target.value;

--- a/src/views/Post/PostCreatePage/PostCreatePage.jsx
+++ b/src/views/Post/PostCreatePage/PostCreatePage.jsx
@@ -13,7 +13,6 @@ import {
   Content,
   PetPhoto
 } from './Category';
-import ErrorModal from './ErrorModal/ErrorModal';
 import useForm from '@/hooks/useForm';
 import { placeData, animalData } from '@/data/data';
 
@@ -133,7 +132,6 @@ const PostCreatePage = () => {
             취소하기
           </Button>
         </ButtonWrapper>
-        {isErrorExist && <ErrorModal onClose={() => setIsErrorExist(false)} />}
       </Form>
     </Wrapper>
   );


### PR DESCRIPTION
## 개선 전
![image](https://user-images.githubusercontent.com/81841082/154826239-d8d22c49-cf13-43fc-8368-7cccb824bbf9.png)

위 PostCreatePage의 상태 정보, 날짜, 장소 카테고리들 중, 하나의 카테고리를 유저가 선택하는 경우, 나머지 카테고리들이 리렌더링

![image](https://user-images.githubusercontent.com/81841082/154826299-4deaa628-0160-4d66-a157-dec24730e2e8.png)
첫 번째 commit이 발생할 때 결과

![image](https://user-images.githubusercontent.com/81841082/154826383-228b6751-1c58-4671-819a-18b85cb92676.png)
두 번째 commit이 발생할 때 결과

유저가 2012년을 선택하고 1월을 선택하는 경우, 4차례의 commit이 발생
- 첫 번째 commit과 두 번째 commit은 '년도'를 선택할 때 발생.
- 첫 번째 commit은 Date 카테고리 컴포넌트만 리렌더링, 14.3ms 소요. (위의 첫 번째 사진 참조)
- 두 번째 commit은 **PostCreatePage 하위의 모든 카테고리 컴포넌트 리렌더링**, 10.9ms 소요. (위의 두 번째 사진 참조)

![image](https://user-images.githubusercontent.com/81841082/154826510-f388d87d-d2c3-41e5-a2a2-d79c04c7661f.png)

세 번째 commit과 네 번째 commit은(위 사진에서 숫자 3과 4) '월'을 선택할 때 발생하며, 첫 번째 commit과 두 번째 commit과 (위 사진에서 1과 2) 유사한 렌더링 시간을 보여주는 것을 막대 그래프를 통해 확인할 수 있음.

즉, 항목을 하나 선택할 때마다 두 번째 commit 시간인 10.9ms의 시간(변동 가능)이 소요됨

## 개선 후

개선 전에는 **PostCreatePage 하위의 모든 카테고리 컴포넌트 리렌더링**되는 것이 문제였음.

이를 해결하기 위해서 하위 컴포넌트들에 React.memo를 적용함. 변경 후 Profiler 데이터는 아래와 같음.

![image](https://user-images.githubusercontent.com/81841082/154826599-8c7bf20a-a0e7-4b2f-b337-441f524d78c9.png)
첫 번째 commit이 발생할 때 결과

![image](https://user-images.githubusercontent.com/81841082/154826612-45dd40f1-dfb7-4e06-a909-5ea1d5e17dbd.png)
두 번째 commit이 발생할 때 결과

![image](https://user-images.githubusercontent.com/81841082/154826686-c40dabe6-3b0c-4fee-a5b5-e6ce2e5d05c6.png)

PostCreatePage 하위의 모든 카테고리 컴포넌트 리렌더링 문제를 해결한 것을 확인할 수 있으며, 항목을 하나 선택할 때마다 소요되는 시간이 대폭 줄어든 것을 확인할 수 있음.

## 참고문헌
[React Profiler](https://ko.reactjs.org/blog/2018/09/10/introducing-the-react-profiler.html)
