### PR TITLE
PostCreatePage 버그 수정 및 가독성 향상, 함수형 프로그래밍 적용, 오타 수정을 위한 리펙토링

### DIFF
--- a/src/components/Slider/Dots.jsx
+++ b/src/components/Slider/Dots.jsx
@@ -7,7 +7,7 @@ const Dots = ({ length, targetIndex, handleClick }) => {
     <Wrapper onClick={handleClick}>
       {length >= 2 &&
         Array.from({ length }).map((_, index) => (
-          <Dot id={index} key={index} targetIndex={targetIndex === index} />
+          <Dot id={index} key={index} targetIndex={targetIndex === index} type="button" />
         ))}
     </Wrapper>
   );

--- a/src/components/Slider/SliderButton.jsx
+++ b/src/components/Slider/SliderButton.jsx
@@ -17,7 +17,8 @@ const SliderButton = ({ direction, handleSlide }) => {
       left={(direction === 'left' && '1rem') || 'auto'}
       right={(direction === 'right' && '1rem') || 'auto'}
       direction={direction}
-      onClick={handleSlide}>
+      onClick={handleSlide}
+      type="button">
       {(direction === 'right' && <NextArrow />) || (direction === 'left' && <PrevArrow />)}
     </Button>
   );

--- a/src/utils/fxjs.js
+++ b/src/utils/fxjs.js
@@ -1,0 +1,82 @@
+export const Lazy = {};
+
+export const isLength = {};
+
+isLength.GreaterThanOrEqual = (number) => {
+  return (iter) => iter.length >= number;
+};
+
+isLength.GreaterThan = (number) => {
+  return (iter) => iter.length > number;
+};
+
+isLength.LessThanOrEqual = (number) => {
+  return (iter) => iter.length <= number;
+};
+
+isLength.LessThan = (number) => {
+  return (iter) => iter.length < number;
+};
+
+isLength.Equal = (number) => {
+  return (iter) => iter.length === number;
+};
+
+export const curry =
+  (appliedFunc) =>
+  (firstElement, ...remainElements) =>
+    remainElements.length
+      ? appliedFunc(firstElement, ...remainElements)
+      : (...nextElemenets) => appliedFunc(firstElement, ...nextElemenets);
+
+export const reduce = curry((appliedFunc, acc, iter) => {
+  if (!iter) {
+    acc = (iter = acc[Symbol.iterator]()).next().value;
+  }
+
+  for (const value of iter) {
+    acc = appliedFunc(acc, value);
+  }
+
+  return acc;
+});
+
+export const go = (...elements) =>
+  reduce((initialValue, appliedFunc) => appliedFunc(initialValue), elements);
+
+export const pipe =
+  (firstFunction, ...remainFunctions) =>
+  (...elements) =>
+    go(firstFunction(...elements), ...remainFunctions);
+
+export const take = curry((limiter, iter) => {
+  const res = [];
+
+  for (const value of iter) {
+    res.push(value);
+    if (res.length === limiter) return res;
+  }
+
+  return res;
+});
+
+export const identity = (v) => !v;
+
+export const find = curry((appliedFunc, iter) => {
+  let cur = null;
+  iter = iter[Symbol.iterator]();
+
+  while (!(cur = iter.next()).done) {
+    if (appliedFunc(cur.value)) return cur.value;
+  }
+});
+
+export const getDataMadeBy = curry((appliedFunc, data) => appliedFunc(data));
+
+Lazy.map = curry(function* (appliedFunc, iter) {
+  for (const value of iter) yield appliedFunc(value);
+});
+
+Lazy.filter = curry(function* (appliedFunc, iter) {
+  for (const value of iter) if (appliedFunc(value)) yield value;
+});

--- a/src/views/Post/PostCreatePage/Category/Contact/Contact.jsx
+++ b/src/views/Post/PostCreatePage/Category/Contact/Contact.jsx
@@ -5,7 +5,7 @@ import { Label } from '@/components/Label';
 import { Input } from '@/components/Input';
 
 const Contact = ({ margin, onFillIn, onLeaveBlank }) => {
-  const handleInput = (e) => {
+  const handleInputTelNumber = (e) => {
     isInputEmpty(e) ? onLeaveBlank('telNumber') : onFillIn({ telNumber: e.target.value });
   };
 
@@ -20,7 +20,7 @@ const Contact = ({ margin, onFillIn, onLeaveBlank }) => {
         maxLength="15"
         margin="1.8rem 0 0 0"
         required
-        onChange={handleInput}
+        onChange={handleInputTelNumber}
       />
     </Wrapper>
   );

--- a/src/views/Post/PostCreatePage/Category/Date/Date.jsx
+++ b/src/views/Post/PostCreatePage/Category/Date/Date.jsx
@@ -12,7 +12,7 @@ const Date = ({ margin, onFillIn, onLeaveBlank }) => {
 
   const handleChange = (e) => {
     if (isYearSelection(e)) {
-      if (isDefaultOptionSelecetd(e)) {
+      if (isDefaultOptionSelected(e)) {
         setSelectedYear(null);
         setSelectedMonth(null);
         setSelectedDay(null);
@@ -23,7 +23,7 @@ const Date = ({ margin, onFillIn, onLeaveBlank }) => {
     }
 
     if (isMonthSelection(e)) {
-      if (isDefaultOptionSelecetd(e)) {
+      if (isDefaultOptionSelected(e)) {
         setSelectedMonth(null);
         setSelectedDay(null);
       } else {
@@ -33,7 +33,7 @@ const Date = ({ margin, onFillIn, onLeaveBlank }) => {
     }
 
     if (isDaySelection(e)) {
-      isDefaultOptionSelecetd(e) ? setSelectedDay(null) : setSelectedDay(Number(e.target.value));
+      isDefaultOptionSelected(e) ? setSelectedDay(null) : setSelectedDay(Number(e.target.value));
       return;
     }
   };
@@ -155,7 +155,7 @@ const isMonthThatHas30Days = (month) => [4, 6, 9, 11].includes(month);
 const isYearSelection = (e) => e.target[0].textContent === '년';
 const isMonthSelection = (e) => e.target[0].textContent === '월';
 const isDaySelection = (e) => e.target[0].textContent === '일';
-const isDefaultOptionSelecetd = (e) => e.target[0].textContent === e.target.value;
+const isDefaultOptionSelected = (e) => e.target[0].textContent === e.target.value;
 const areAllOptionsSelected = (year, month, day) => year && month && day;
 const makeYYYYMMDDForm = (number) => (number < 10 && `0${number}`) || number;
 const February = 2;

--- a/src/views/Post/PostCreatePage/Category/PetInformation/PetInformation.jsx
+++ b/src/views/Post/PostCreatePage/Category/PetInformation/PetInformation.jsx
@@ -1,167 +1,18 @@
-import React, { useState, useEffect, useRef, useMemo, memo } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import styled from '@emotion/styled';
 import LineBreakWrapper from '../Common/LineBreakWrapper';
 import { Label } from '@/components/Label';
-import { SelectionBox } from '@/components/SelectionBox';
-import { Input } from '@/components/Input';
-import { CheckBox } from '@/components/CheckBox';
+import AgeAndSex from './sub/AgeAndSex';
+import Kind from './sub/Kind';
 
 const PetInformation = ({ margin, animals, onFillIn, onLeaveBlank }) => {
-  const [animal, setAnimal] = useState('동물');
-  const [animalKindName, setAnimalKindName] = useState(null);
-  const [isAnimalUnknown, setIsAnimalUnknown] = useState(false);
-  const kindsSelectionBoxRef = useRef(null);
-  const kindsCheckBoxRef = useRef(null);
-
-  const animalList = useMemo(() => {
-    const selectedAnimal = animals.find(({ name }) => name === animal);
-    const selectedKinds = selectedAnimal?.kinds;
-    const res = selectedKinds?.map(({ name }) => name);
-    return res;
-  }, [animal, animals]);
-
-  useEffect(() => {
-    if (!isAnimalSelected(animal)) {
-      onLeaveBlank('animalId');
-    } else {
-      const selectedAniaml = animals?.find(({ name }) => name === animal);
-      const selectedId = selectedAniaml?.id;
-      onFillIn({ animalId: selectedId });
-    }
-  }, [animal]);
-
-  const handleChange = (e) => {
-    if (isCheckBoxChecked(e)) {
-      setIsAnimalUnknown(!isAnimalUnknown);
-      const valueToSave = (e.target.checked && 'UNKNOWN') || animalKindName || null;
-      onFillIn({ animalKindName: valueToSave });
-      return;
-    }
-
-    if (isInputChange(e)) {
-      if (isKindsInput(e)) {
-        if (isEmpty(e)) {
-          onLeaveBlank('animalKindName');
-        } else {
-          onFillIn({ animalKindName: e.target.value });
-        }
-        return;
-      }
-
-      if (isAgeInput(e)) {
-        if (isEmpty(e)) {
-          onLeaveBlank('age', -1);
-        } else {
-          const age = e.target.value;
-          if (age >= maxAge) e.target.value = maxAge;
-          else if (age < minAge) e.target.value = minAge;
-          onFillIn({ age: Number(e.target.value) });
-        }
-        return;
-      }
-    }
-
-    if (isSelectChange(e)) {
-      if (isAnimalSelection(e)) {
-        if (isDefalutOptionSelected(e)) {
-          setAnimal(null);
-          onLeaveBlank('animalId');
-        } else {
-          setAnimal(e.target.value);
-          onFillIn({ animalId: e.target.value });
-        }
-
-        kindsCheckBoxRef.current && (kindsCheckBoxRef.current.checked = false);
-        kindsSelectionBoxRef.current && (kindsSelectionBoxRef.current[0].selected = 'selected');
-        setIsAnimalUnknown(false);
-        onLeaveBlank('animalKindName');
-        return;
-      }
-
-      if (isKindsSelection(e)) {
-        if (isDefalutOptionSelected(e)) {
-          setAnimalKindName(null);
-          onLeaveBlank('animalKindName');
-        } else {
-          setAnimalKindName(e.target.value);
-          onFillIn({ animalKindName: e.target.value });
-        }
-        return;
-      }
-
-      if (isSexSelection(e)) {
-        if (isDefalutOptionSelected(e)) {
-          onLeaveBlank('sex', 'UNKNOWN');
-        } else {
-          onFillIn({
-            sex:
-              (e.target.value === '수컷' && 'MALE') ||
-              (e.target.value === '암컷' && 'FEMALE') ||
-              (e.target.value === '모름' && 'UNKNOWN')
-          });
-        }
-        return;
-      }
-    }
-  };
-
   return (
-    <Wrapper margin={margin} onChange={handleChange}>
+    <Wrapper margin={margin}>
       <Label bgColor="brand">동물 정보</Label>
       <LineBreakWrapper margin="1.8rem 0 0 0">
-        <SelectionBox
-          ariaLabel="animal"
-          options={['개', '고양이', '기타']}
-          defaultOption="동물"
-          required
-        />
-        {((animal === '동물' || animal === null) && <></>) ||
-          (animal === '기타' && (
-            <>
-              <Input
-                ariaLabel="kinds"
-                placeholder="동물명 혹은 품종"
-                width="50%"
-                margin="0 0 0 1.8rem"
-                maxLength="50"
-                required
-                disabled={isAnimalUnknown}
-              />
-              <CheckBox
-                ariaLabel="dont know kinds"
-                margin="0 0 0 1.2rem"
-                fontSize="1.4rem"
-                propRef={kindsCheckBoxRef}
-              />
-            </>
-          )) || (
-            <LineBreakWrapper>
-              <SelectionBox
-                defaultOption="품종"
-                margin="1.6rem 0 0 0"
-                required
-                options={animalList}
-                disabled={isAnimalUnknown}
-                propRef={kindsSelectionBoxRef}
-              />
-            </LineBreakWrapper>
-          )}
-        <LineBreakWrapper>
-          <Input
-            ariaLabel="age"
-            width="10rem"
-            placeholder="나이"
-            type="number"
-            margin="1.8rem 0 0 0"
-          />
-          <SelectionBox
-            ariaLabel="sex"
-            options={['수컷', '암컷']}
-            defaultOption="성별"
-            margin="0 0 0 1.6rem"
-          />
-        </LineBreakWrapper>
+        <Kind animals={animals} onFillIn={onFillIn} onLeaveBlank={onLeaveBlank} />
+        <AgeAndSex onFillIn={onFillIn} onLeaveBlank={onLeaveBlank} />
       </LineBreakWrapper>
     </Wrapper>
   );
@@ -178,18 +29,4 @@ PetInformation.propTypes = {
   margin: PropTypes.string
 };
 
-export default memo(PetInformation);
-
-const isSelectChange = (e) => e.target.tagName === 'SELECT';
-const isInputChange = (e) => e.target.tagName === 'INPUT';
-const isKindsInput = (e) => e.target.id === 'kinds-input';
-const isAgeInput = (e) => e.target.id === 'age-input';
-const isAnimalSelection = (e) => e.target[0].textContent === '동물';
-const isAnimalSelected = (animal) => animal === '동물';
-const isKindsSelection = (e) => e.target[0].textContent === '품종';
-const isSexSelection = (e) => e.target[0].textContent === '성별';
-const isDefalutOptionSelected = (e) => e.target[0].textContent === e.target.value;
-const isEmpty = (e) => e.target.value.length === 0;
-const isCheckBoxChecked = (e) => e.target.type === 'checkbox';
-const maxAge = 499;
-const minAge = 0;
+export default PetInformation;

--- a/src/views/Post/PostCreatePage/Category/PetInformation/sub/AgeAndSex.js
+++ b/src/views/Post/PostCreatePage/Category/PetInformation/sub/AgeAndSex.js
@@ -1,0 +1,29 @@
+import React from 'react';
+import LineBreakWrapper from '../../Common/LineBreakWrapper';
+import { SelectionBox } from '@/components/SelectionBox';
+import { Input } from '@/components/Input';
+
+const AgeAndSex = () => {
+  return (
+    <LineBreakWrapper>
+      <Input
+        ariaLabel="age"
+        name="age-input"
+        width="10rem"
+        placeholder="나이"
+        type="number"
+        margin="1.8rem 0 0 0"
+      />
+      <SelectionBox
+        ariaLabel="sex"
+        options={['수컷', '암컷']}
+        defaultOption="성별"
+        margin="0 0 0 1.6rem"
+      />
+    </LineBreakWrapper>
+  );
+};
+
+AgeAndSex.propTypes = {};
+
+export default AgeAndSex;

--- a/src/views/Post/PostCreatePage/Category/PetInformation/sub/Kind.jsx
+++ b/src/views/Post/PostCreatePage/Category/PetInformation/sub/Kind.jsx
@@ -1,0 +1,171 @@
+import React, { useState, useRef } from 'react';
+import PropTypes from 'prop-types';
+import LineBreakWrapper from '../../Common/LineBreakWrapper';
+import { SelectionBox } from '@/components/SelectionBox';
+import { Input } from '@/components/Input';
+import { CheckBox } from '@/components/CheckBox';
+import { isLength as isInputLength, find, getDataMadeBy, Lazy, take, go } from '@/utils/fxjs';
+
+const Kind = ({ animals, onFillIn, onLeaveBlank }) => {
+  const [animal, setAnimal] = useState('');
+  const [animalKindName, setAnimalKindName] = useState('');
+  const [isAnimalUnknown, setIsAnimalUnknown] = useState(false);
+  const [animalList, setAnimalList] = useState([]);
+  const kindsSelectionBoxRef = useRef(null);
+  const kindsCheckBoxRef = useRef(null);
+
+  const handleInitializeCheckBoxAndSelectionBox = () => {
+    kindsCheckBoxRef.current && (kindsCheckBoxRef.current.checked = false);
+    kindsSelectionBoxRef.current && (kindsSelectionBoxRef.current[0].selected = 'selected');
+  };
+
+  const handleFillInAnimalId = (animal) => {
+    const animalId = go(
+      animals,
+      find(({ name }) => name === animal),
+      getDataMadeBy((data) => data?.id)
+    );
+
+    onFillIn({ animalId });
+  };
+
+  const handleSetAnimalList = (animal) => {
+    const animalList = go(
+      animals,
+      find(({ name }) => name === animal),
+      getDataMadeBy((data) => data?.kinds),
+      Lazy.map(({ name }) => name),
+      take(Infinity)
+    );
+
+    setAnimalList(animalList);
+  };
+
+  const handleFillInAnimalKindName = (e) => {
+    let valueToFillIn = null;
+
+    if (isCheckboxChecked(e)) {
+      valueToFillIn = 'UNKNOWN';
+    } else if (wasAnimalKindNameEntered(animalKindName)) {
+      valueToFillIn = animalKindName;
+    } else {
+      valueToFillIn = null;
+    }
+
+    onFillIn({ animalKindName: valueToFillIn });
+  };
+
+  const render = (animal) => {
+    switch (animal) {
+      case '':
+      case '동물':
+        return null;
+      case '기타':
+        return (
+          <>
+            <Input
+              ariaLabel="kinds"
+              placeholder="동물명 혹은 품종"
+              width="50%"
+              margin="0 0 0 1.8rem"
+              maxLength="50"
+              disabled={isAnimalUnknown}
+              required
+              onChange={(e) => {
+                if (isInputLength.equal(0)(e.target.value)) {
+                  onLeaveBlank('animalKindName');
+                  return;
+                }
+
+                const animalKindName = e.target.value;
+                setAnimalKindName(animalKindName);
+                onFillIn({ animalKindName });
+              }}
+            />
+            <CheckBox
+              id="dont-know-kinds"
+              ariaLabel="dont know kinds"
+              margin="0 0 0 1.2rem"
+              fontSize="1.4rem"
+              onChange={(e) => {
+                setIsAnimalUnknown(!isAnimalUnknown);
+                handleFillInAnimalKindName(e);
+              }}
+              propRef={kindsCheckBoxRef}
+            />
+          </>
+        );
+      default:
+        return (
+          <LineBreakWrapper>
+            <SelectionBox
+              ariaLabel="kinds"
+              defaultOption="품종"
+              margin="1.6rem 0 0 0"
+              required
+              options={animalList || []}
+              disabled={isAnimalUnknown}
+              propRef={kindsSelectionBoxRef}
+              onChange={(e) => {
+                if (isDefaultOptionSelected(e)) {
+                  setAnimalKindName('');
+                  onLeaveBlank('animalKindName');
+                  return;
+                }
+
+                const animalKindName = e.target.value;
+                setAnimalKindName(animalKindName);
+                onFillIn({ animalKindName });
+              }}
+            />
+          </LineBreakWrapper>
+        );
+    }
+  };
+
+  return (
+    <>
+      <SelectionBox
+        ariaLabel="animal"
+        options={['개', '고양이', '기타']}
+        defaultOption="동물"
+        required
+        onFillIn={onFillIn}
+        onLeaveBlank={onLeaveBlank}
+        onChange={(e) => {
+          if (isDefaultOptionSelected(e)) {
+            setAnimal('');
+            setAnimalKindName('');
+            setAnimalList([]);
+            onLeaveBlank('animalId');
+            onLeaveBlank('animalKindName');
+            return;
+          }
+
+          const selectedAnimal = e.target.options[e.target.selectedIndex].value;
+          setAnimal(selectedAnimal);
+          setIsAnimalUnknown(false);
+          handleInitializeCheckBoxAndSelectionBox();
+          handleFillInAnimalId(selectedAnimal);
+          handleSetAnimalList(selectedAnimal);
+          onLeaveBlank('animalKindName');
+        }}
+      />
+      {render(animal)}
+    </>
+  );
+};
+
+Kind.propTypes = {
+  animals: PropTypes.array,
+  isAnimalUnknown: PropTypes.bool,
+  onFillIn: PropTypes.func,
+  onLeaveBlank: PropTypes.func
+};
+
+export default Kind;
+
+const isCheckboxChecked = (e) => e.target.checked;
+const wasAnimalKindNameEntered = (animalKindName) =>
+  isInputLength.GreaterThanOrEqual(1)(animalKindName);
+const isDefaultOptionSelected = (e) => e.target[0].textContent === e.target.value;

--- a/src/views/Post/PostCreatePage/Category/Status/Status.jsx
+++ b/src/views/Post/PostCreatePage/Category/Status/Status.jsx
@@ -13,7 +13,7 @@ const STATUS = Object.freeze({
 });
 
 const Status = ({ onFillIn, onLeaveBlank }) => {
-  const handleChange = (e) => {
+  const handleSelectStatus = (e) => {
     isDefalutOptionSelected(e)
       ? onLeaveBlank('status')
       : onFillIn({ status: STATUS[e.target.value] });
@@ -27,7 +27,7 @@ const Status = ({ onFillIn, onLeaveBlank }) => {
       <LineBreakWrapper margin="1.8rem 0 0 0">
         <SelectionBox
           id="status"
-          onChange={handleChange}
+          onChange={handleSelectStatus}
           options={['실종', '목격', '보호', '완료']}
           defaultOption="상태 옵션"
           required


### PR DESCRIPTION
## 함수형 프로그래밍 적용
![image](https://user-images.githubusercontent.com/81841082/155237517-9317f025-a92c-43dc-81f0-e080d3c2e33c.png)
변경 전에는 데이터를 저장하기 위한 변수 선언이 자주 등장하여, 코드가 길고, 변수명이 겹쳐서 충돌하는 문제가 존재하였음. fxjs를 구성한 결과, 변수 선언은 줄어들고, 앞으로만 가는 코드로 구성되어 추후 고치기도 쉬울 것으로 예상됨.

## PetInformation 렌더링 태그들을 sub 컴포넌트로 재구성
![image](https://user-images.githubusercontent.com/81841082/155237956-a588e146-d3be-4fb0-8f30-b9ab10b99bb2.png)
PetInformation 컴포넌트 하나에 너무 많은 상태와 동작이 응집되어 있어 가독성이 현저하게 떨어짐. PetInformation 내의 렌더링 태그들을 Kind와 AgeAndSex의 sub 컴포넌트들로 재구성하여 응집도를 낮춤.

## 이벤트 위임 방식 제거
![image](https://user-images.githubusercontent.com/81841082/155240583-e9c7db40-17b2-4093-9be8-092e1571b908.png)
사진에서 보이듯, 페이지 내 모든 폼 컨트롤 요소의 동작을 하나의 함수에서 관리하고 있음. 이로 인해서 가독성이 심하게 저하되고, 함수형 프로그래밍 패러다임과 어울리지 않는 함수가 만들어진 것을 알 수 있음.

또한 '이벤트 핸들러 등록 개수를 줄이기 위함'만 생각하며 이벤트 위임을 사용하였으나, 대상이 **동일한 동작을 하는 형제 요소 객체들**에 한해서만 효과적임을 알 수 있었음.

이벤트 위임 방식을 제거함으로써 아래와 같이 동물 선택 로직이 if문 개수 감소와 가독성이 향상되었음.
![image](https://user-images.githubusercontent.com/81841082/155239969-11236b7f-1ec8-4980-9e5d-bf6008de3cac.png)

내부 코드를 살펴보면, 유저가 동물을 선택했을 때에 대한 책임만을 갖는 프로시저이며, 프로시저 내부는 form 업데이트 함수와 부가적인 상태 업데이트를 위한 많은 함수들로 조합이 돼있으나, 각 함수가 한 가지 로직만을 갖고 있기 때문에 조합성이 높다고 판단됨
![image](https://user-images.githubusercontent.com/81841082/155504408-9aa8c46c-c408-4e55-be2b-0bff87241efb.png)
